### PR TITLE
Updated to use previous version of swift tools

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "TinyStorage",
-    platforms: [.iOS(.v14), .tvOS(.v14), .visionOS(.v1), .watchOS(.v10), .macOS(.v11)],
+    platforms: [.iOS(.v14), .tvOS(.v14), .watchOS(.v9), .macOS(.v11)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(


### PR DESCRIPTION
Updated to use version 5.7 of swift tools not 6.0 so it will work with older versions of Xcodebuild